### PR TITLE
Reformat arguments and options order

### DIFF
--- a/src/main/java/ch/heigvd/commands/Root.java
+++ b/src/main/java/ch/heigvd/commands/Root.java
@@ -27,24 +27,21 @@ public class Root {
     @CommandLine.Option(
             names = {"-p", "--pattern"},
             description = "pattern to find in file",
-            required = true,
-            scope = CommandLine.ScopeType.INHERIT
+            required = true
     )
     private String pattern;
 
     @CommandLine.Option(
             names = {"-r", "--repeat"},
             description = "transform all occurrences",
-            required = false,
-            scope = CommandLine.ScopeType.INHERIT
+            required = false
     )
     private boolean repeat;
 
     @CommandLine.Option(
             names = {"-e", "--regex"},
             description = "match regex pattern instead, max 1 match group",
-            required = false,
-            scope = CommandLine.ScopeType.INHERIT
+            required = false
     )
     private boolean regex;
 


### PR DESCRIPTION
Now options for regex, pattern and repeat have to be specified before subcommand:
```
java -jar ./target/dai-lab01-cli-1.0-SNAPSHOT.jar case --pattern pat <infile> <outfile>
Missing required option: '--pattern=<pattern>
```